### PR TITLE
Handle short signals in FIR padding

### DIFF
--- a/tools/denoise.py
+++ b/tools/denoise.py
@@ -54,7 +54,15 @@ class FixedFIR1D(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         K = self.kernel.size(-1)
         pad = K // 2
-        x = F.pad(x, (pad, pad), mode="reflect")
+        # "reflect" padding requires the padding size to be smaller than the
+        # input length, otherwise PyTorch raises an error.  When processing very
+        # short segments (e.g. 0.5 s signals with only 250 samples), the FIR
+        # kernel (K=1001) would need padding larger than the signal itself.  In
+        # such cases fall back to zero padding which has no such restriction.
+        if x.size(-1) <= pad:
+            x = F.pad(x, (pad, pad), mode="constant")
+        else:
+            x = F.pad(x, (pad, pad), mode="reflect")
         weight = self.kernel.repeat(self.in_channels, 1, 1)  # (C,1,K)
         return F.conv1d(x, weight, groups=self.in_channels)
 


### PR DESCRIPTION
## Summary
- avoid reflect padding errors for short EEG segments by falling back to zero padding

## Testing
- `python S3-submission/main.py --input S3-submission/0.5s --output S3-submission/result-0.5 --model S3-submission/model.pth`


------
https://chatgpt.com/codex/tasks/task_e_68a8226f45088320a6f52e83c5babc18